### PR TITLE
build: fix build on non-Windows with `winapp` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "monitor-input"
-version = "1.2.8"
+version = "1.2.9"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitor-input"
-version = "1.2.8"
+version = "1.2.9"
 edition = "2024"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
 description = "A command line tool to change input sources of display monitors with DDC/CI."

--- a/src/main_winapp.rs
+++ b/src/main_winapp.rs
@@ -1,12 +1,20 @@
-#![cfg_attr(feature = "winapp", windows_subsystem = "windows")]
+#![cfg_attr(
+    all(feature = "winapp", target_os = "windows"),
+    windows_subsystem = "windows"
+)]
 
+#[cfg(all(feature = "winapp", target_os = "windows"))]
 use std::fmt;
 
+#[cfg(all(feature = "winapp", target_os = "windows"))]
 use clap::Parser;
+#[cfg(all(feature = "winapp", target_os = "windows"))]
 use toast_logger_win::{Notification, ToastLogger};
 
+#[cfg(all(feature = "winapp", target_os = "windows"))]
 use monitor_input::{Cli, Monitor};
 
+#[cfg(all(feature = "winapp", target_os = "windows"))]
 fn main() -> anyhow::Result<()> {
     let mut cli: Cli = Cli::parse();
     init_logger(cli.verbose);
@@ -16,6 +24,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(all(feature = "winapp", target_os = "windows"))]
 fn init_logger(verbose: u8) {
     ToastLogger::builder()
         .auto_flush(false)
@@ -42,3 +51,6 @@ fn init_logger(verbose: u8) {
         .init()
         .unwrap();
 }
+
+#[cfg(not(all(feature = "winapp", target_os = "windows")))]
+include!("main.rs");


### PR DESCRIPTION
Applying the `winapp` feature on non-Windows platform generates the same binary as without the feature, instead of build failures.
