### PR TITLE
feat: make Windows subsystem version by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -482,7 +482,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "monitor-input"
-version = "1.2.9"
+version = "1.2.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "monitor-input"
-version = "1.2.9"
+version = "1.2.10"
 edition = "2024"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
 description = "A command line tool to change input sources of display monitors with DDC/CI."
@@ -16,7 +16,7 @@ default-run = "monitor-input"
 anyhow = "1.0.102"
 clap = { version = "4.6.1", features = ["derive"] }
 ddc-hi = "0.4.1"
-env_logger = { version = "0.11.10", optional = true }
+env_logger = "0.11.10"
 log = "0.4.32"
 mccs-db = "0.1.3"
 regex = "1.12.3"
@@ -25,19 +25,17 @@ strum = "0.28.0"
 strum_macros = "0.28.0"
 
 [target.'cfg(windows)'.dependencies]
-toast-logger-win = { version = "0.5.2", optional = true }
+toast-logger-win = "0.5.2"
 
 [features]
-default = ["console"]
-console = ["dep:env_logger"]
-winapp = ["dep:toast-logger-win"]
+# The `winapp` feature is no longer used since 1.2.10,
+# but is kept as no-op so that existing install doesn't fail.
+winapp = []
 
 [[bin]]
 name = "monitor-input"
-required-features = ["console"]
 path = "src/main.rs"
 
 [[bin]]
 name = "monitor-inputw"
-required-features = ["winapp"]
 path = "src/main_winapp.rs"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ A command line tool to change input sources of display monitors with [DDC/CI].
 ## Prerequisites
 
 * [Install Rust] if it's not installed yet.
-* On Windows, please also see [Windows App](#windows-app).
-* On Linux, `libudev` is required. See [libudev-sys].
+* On Linux, `libudev` is required. Please see [libudev-sys].
 
 [libudev-sys]: https://github.com/dcuddeback/libudev-sys
 
@@ -69,21 +68,19 @@ a console window pops up.
 
 To run it from non-console applications
 without seeing the console window popping up,
-a Windows subsystem version is available as an optional feature.
-Please add `-F winapp` to the `cargo install` command.
-```shell-session
-cargo install monitor-input -F winapp
-```
-The `-F winapp` option installs
-the `monitor-inputw.exe` (note the `w` suffix)
-in addition to the `monitor-input.exe`.
+a Windows subsystem version `monitor-inputw` (note the `w` suffix) is installed
+by default alongside the standard `monitor-input` executable.
 The executable with the `w` suffix is a Windows subsystem application.
 
-Because the Windows applications can't print to console,
+On platforms other than Windows,
+`monitor-inputw` is also created
+but is functionally equivalent to `monitor-input`.
+
+Because Windows applications can't print to console,
 errors are shown in the [Windows toast notifications].
 If you want to see more informational messages
 such as the monitor input source changes,
-please add the `-v` option to the `monitor-inputw`.
+please add the `-v` option to `monitor-inputw`.
 
 [Windows toast notifications]: https://learn.microsoft.com/windows/apps/design/shell/tiles-and-notifications/toast-notifications-overview
 

--- a/src/main_winapp.rs
+++ b/src/main_winapp.rs
@@ -1,20 +1,17 @@
-#![cfg_attr(
-    all(feature = "winapp", target_os = "windows"),
-    windows_subsystem = "windows"
-)]
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
 
-#[cfg(all(feature = "winapp", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 use std::fmt;
 
-#[cfg(all(feature = "winapp", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 use clap::Parser;
-#[cfg(all(feature = "winapp", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 use toast_logger_win::{Notification, ToastLogger};
 
-#[cfg(all(feature = "winapp", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 use monitor_input::{Cli, Monitor};
 
-#[cfg(all(feature = "winapp", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 fn main() -> anyhow::Result<()> {
     let mut cli: Cli = Cli::parse();
     init_logger(cli.verbose);
@@ -24,7 +21,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(all(feature = "winapp", target_os = "windows"))]
+#[cfg(target_os = "windows")]
 fn init_logger(verbose: u8) {
     ToastLogger::builder()
         .auto_flush(false)
@@ -52,5 +49,5 @@ fn init_logger(verbose: u8) {
         .unwrap();
 }
 
-#[cfg(not(all(feature = "winapp", target_os = "windows")))]
+#[cfg(not(target_os = "windows"))]
 include!("main.rs");


### PR DESCRIPTION
The `winapp` feature is no longer necessary. It is kept as no-op for the compatibility.

On other platforms than Windows, the `w` suffix is also created but is functionally equivalent.
